### PR TITLE
Bump PyYAML file to 6.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ the [documentation](http://www.mattcmccallum.com/scooch/docs).
 
 
 REQUIRED_PACKAGES = [
-    'pyyaml==5.4.1',
+    'pyyaml==6.0.1',
     'sphinx',
     'sphinx_rtd_theme==0.5.1',
     'ruamel.yaml==0.16.12',


### PR DESCRIPTION
A bunch of python versions have problems with the pyyaml==5.4.1 file: https://github.com/yaml/pyyaml/issues/724

The repo continues to work completely fine with pyyaml==6.0.1. To avoid breaking dependent packages (in my case MULE), it is beneficial to update this library