### PR TITLE
v1.0.3

### DIFF
--- a/scooch/__init__.py
+++ b/scooch/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2021 Pandora Media, LLC.
+# Copyright 2023 Pandora Media, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ from .config_list import *
 from .config_collection import *
 from .config_factory import *
 from .param import Param
+from .alias_param import AliasParam
 from .configurable_factory import ConfigurableFactory
 
 # TODO [matt.c.mccallum 01.05.21]: Remove the two below in favor of the config factory, once legacy codebases are updated.

--- a/scooch/alias_param.py
+++ b/scooch/alias_param.py
@@ -1,0 +1,110 @@
+# coding=utf-8
+# Copyright 2023 Pandora Media, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Python standard library imports
+# None.
+
+# Third party imports
+# None.
+
+# Local imports
+from . import ParamDefaults
+from .param import Param
+
+
+class AliasParam(Param):
+    """
+    A parameter that is deterministically derived from other parameters.
+    """
+
+    def __init__(self, param_type, source_param_names, transform_function, doc=None):
+        """
+        ** Constructor **
+
+        Args:
+            param_type: type - The type of the derived parameter.
+
+            source_param_names: list(str) - A list of the names of parameters that this parameter is
+            derived from / is an alias for.
+
+            transform_function: func - A function that takes in the parameters defined in 
+            source_param_names, and produces the value of this parameter (an alias of the former).
+
+            doc: str - A doc string describing this parameter. If set to None, a string describing
+            which parameters this parameter is an alias for will be automatically produced.
+        """
+        self._type = param_type
+        self._transform_function = transform_function
+        self._source_param_names = source_param_names
+
+        self._doc = doc
+        if doc is None:
+            self._doc = f"An alias for the transformation: {self._transform_function.__name__}, \
+                          applied to the parameters {source_param_names} in class \
+                          {self.__class__.__name__}"
+            
+        # TODO [matt.c.mccallum 12.18.23]: Check for circular aliases here.
+        # TODO [matt.c.mccallum 12.18.23]: Ensure the output type is not a ConfigurableMeta, 
+        #      ConfigList or ConfigCollection.
+
+    @property
+    def default(self):
+        return ParamDefaults.NO_DEFAULT
+    
+    def __get__(self, instance, owner):
+        """
+        Returns the value of the parameter when the Param is accessed as an attribute
+        of a Configurable class.
+
+        Args:
+            instance: Configurable - The instance of the class that this Param is an 
+            attribute of.
+
+            owner: Configurable - The class that this Param is a Param of.
+
+        Return: 
+            self.type - The value of the aliased parameter.
+        """
+        # TODO [matt.c.mccallum 12.18.23]: Make sure owner is of type Configurable and includes the
+        #      parameters that this parameter is an alias for.
+
+        # If called on the class (i.e., no instance), then return the parameter itself
+        if instance is None:
+            return self
+        # Otherwise return the value
+        param_list = []
+        for name in self._source_param_names:
+            try:
+                arg = getattr(instance, '_'+name)
+            except AttributeError: 
+                arg = getattr(instance, name)
+            param_list += [arg]
+        return self._transform_function(*param_list)
+
+    def __set__(self, instance, value):
+        """
+        Sets the value of the parameter. This is disabled for alias parameters which can only be
+        changed by adjusting the parameters that the alias parameter is an alias for.
+
+        Args:
+            instance: Configurable - The instance to change the value of a config item for.
+
+            value: object - The value to change the config item to.
+        """
+        raise AttributeError(f'Attempted to set value of SCOOCH parameter {self.name} on an \
+                             instance of {instance.__class__.__name__}. This parameter is an alias \
+                             and cannot be set directly.')
+    

--- a/scooch/configurable_meta.py
+++ b/scooch/configurable_meta.py
@@ -140,7 +140,7 @@ class ConfigurableMeta(ABCMeta):
             elif param in list(defaults_dict.keys()):
                 param_value = defaults_dict[param]
                 if '\n' in str(param_value) or len(str(param_value)) > 40:
-                    param_value = f" (Default is of type {type(param_value)})"
+                    default_info = f" (Default is of type {type(param_value)})"
                 else:
                     default_info = f" (Default: {defaults_dict[param]})"
             else:

--- a/scooch/configurize_helper.py
+++ b/scooch/configurize_helper.py
@@ -25,7 +25,7 @@ import functools
 from .configurable import Configurable
 
 
-def configurize(cls=None, base_class=None, init_base_on_construction=True):
+def configurize(cls=None, base_class=None, name_prefix='Scooch', init_base_on_construction=True):
     """
     Takes a class and makes it scooch configurable. This will prepend "Conf" to the class name
     to distinguish it from the class definition. The returned / transformed class will be accessible
@@ -42,7 +42,7 @@ def configurize(cls=None, base_class=None, init_base_on_construction=True):
         class - The augmented Configurable class that may be configured via scooch.
     """
 
-    def configurize_impl(cls, base_cls=None, init_base_on_construction=True):
+    def configurize_impl(cls, base_cls=None, name_prefix='Scooch', init_base_on_construction=True):
 
         # TODO [matt.c.mccallum 11.08.21]: Check the class `cls` is not already `Configurable`
         # TODO [matt.c.mccallum 11.08.21]: Check that `base_cls`` is `Configurable`
@@ -55,7 +55,7 @@ def configurize(cls=None, base_class=None, init_base_on_construction=True):
             """
             """
 
-            __SCOOCH_NAME__ = 'Scooch' + cls.__name__
+            __SCOOCH_NAME__ = name_prefix + cls.__name__
 
             # TODO [matt.c.mccallum 11.08.21]: Add type info here
             _BASE_PARAMS = {param: f'<> - Parameter derived by extending base class: {cls.__name__}' for param in inspect.signature(cls.__init__).parameters.keys()}
@@ -97,10 +97,10 @@ def configurize(cls=None, base_class=None, init_base_on_construction=True):
     if base_class is None and cls is None:
         return None
     if base_class is None:
-        return configurize_impl(cls)
+        return configurize_impl(cls, name_prefix=name_prefix, name_prefix=name_prefix, init_base_on_construction=init_base_on_construction)
     elif cls is None:
-        return functools.partial(configurize_impl, base_cls=base_class, init_base_on_construction=init_base_on_construction)
+        return functools.partial(configurize_impl, base_cls=base_class, name_prefix=name_prefix, init_base_on_construction=init_base_on_construction)
     else:
-        return configurize_impl(cls, base_class, init_base_on_construction)
+        return configurize_impl(cls, base_class, name_prefix, init_base_on_construction)
 
 

--- a/scooch/configurize_helper.py
+++ b/scooch/configurize_helper.py
@@ -58,12 +58,12 @@ def configurize(cls=None, base_class=None, init_base_on_construction=True):
             __SCOOCH_NAME__ = 'Scooch' + cls.__name__
 
             # TODO [matt.c.mccallum 11.08.21]: Add type info here
-            _BASE_PARAMS = {param: '<> - Parameter derived by extending base class: {cls.__name__}' for param in inspect.signature(base_cls).parameters.keys()}
-            _BASE_PARAM_DEFAULTS = {param: val.default for param, val in inspect.signature(base_cls).parameters.items()}        
+            _BASE_PARAMS = {param: f'<> - Parameter derived by extending base class: {cls.__name__}' for param in inspect.signature(cls.__init__).parameters.keys()}
+            _BASE_PARAM_DEFAULTS = {param: val.default for param, val in inspect.signature(cls.__init__).parameters.items() if hasattr(val, 'default') and val.default != val.empty}        
             _NAME = base_cls.__name__
 
-            __PARAMS__ = {ky: val for ky, val in _BASE_PARAMS.items() if ky not in ['args', 'kwargs']}
-            __PARAM_DEFAULTS__ = {ky: val for ky, val in _BASE_PARAM_DEFAULTS.items() if ky not in ['args', 'kwargs'] and hasattr(val, 'default') and val.default != val.empty}
+            __PARAMS__ = {ky: val for ky, val in _BASE_PARAMS.items() if ky not in ['self', 'args', 'kwargs']}
+            __PARAM_DEFAULTS__ = {ky: val for ky, val in _BASE_PARAM_DEFAULTS.items() if ky not in ['self', 'args', 'kwargs']}
             
             def __init__(self, cfg=None, *args, **kwargs):
                 """
@@ -99,8 +99,8 @@ def configurize(cls=None, base_class=None, init_base_on_construction=True):
     if base_class is None:
         return configurize_impl(cls)
     elif cls is None:
-        return functools.partial(configurize_impl, base_cls=base_class)
+        return functools.partial(configurize_impl, base_cls=base_class, init_base_on_construction=init_base_on_construction)
     else:
-        return configurize_impl(cls, base_class)
+        return configurize_impl(cls, base_class, init_base_on_construction)
 
 

--- a/scooch/configurize_helper.py
+++ b/scooch/configurize_helper.py
@@ -57,6 +57,8 @@ def configurize(cls=None, base_class=None, name_prefix='Scooch', init_base_on_co
 
             __SCOOCH_NAME__ = name_prefix + cls.__name__
 
+            # TODO [matt.c.mccallum 11.29.23]: Add option to exclude / delete parameters here.
+
             # TODO [matt.c.mccallum 11.08.21]: Add type info here
             _BASE_PARAMS = {param: f'<> - Parameter derived by extending base class: {cls.__name__}' for param in inspect.signature(cls.__init__).parameters.keys()}
             _BASE_PARAM_DEFAULTS = {param: val.default for param, val in inspect.signature(cls.__init__).parameters.items() if hasattr(val, 'default') and val.default != val.empty}        
@@ -97,7 +99,7 @@ def configurize(cls=None, base_class=None, name_prefix='Scooch', init_base_on_co
     if base_class is None and cls is None:
         return None
     if base_class is None:
-        return configurize_impl(cls, name_prefix=name_prefix, name_prefix=name_prefix, init_base_on_construction=init_base_on_construction)
+        return configurize_impl(cls, name_prefix=name_prefix, init_base_on_construction=init_base_on_construction)
     elif cls is None:
         return functools.partial(configurize_impl, base_cls=base_class, name_prefix=name_prefix, init_base_on_construction=init_base_on_construction)
     else:

--- a/scooch/param.py
+++ b/scooch/param.py
@@ -84,6 +84,11 @@ class Param:
             owner: Configurable - The class that this Param is a Param of.
         """
         # TODO [matt.c.mccallum 11.04.21]: Make sure owner is of type Configurable
+
+        # If called on the class (i.e., no instance), then return the parameter itself
+        if instance is None:
+            return self
+        # Otherwise return the value
         return instance._config_instances[self._name]
 
     def __set__(self, instance, value):

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setuptools.setup(
         'make_reqs': MakeReqsCommand
     },
     name='scooch',
-    version='1.0.1',
+    version='1.0.2',
     description='A python module for configuring hierarchical class structures in yaml with defaults',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ the [documentation](http://www.mattcmccallum.com/scooch/docs).
 
 
 REQUIRED_PACKAGES = [
-    'pyyaml==5.4.1',
+    'pyyaml==6.0.1',
     'sphinx',
     'sphinx_rtd_theme==0.5.1',
     'ruamel.yaml==0.16.12',
@@ -105,7 +105,7 @@ setuptools.setup(
         'make_reqs': MakeReqsCommand
     },
     name='scooch',
-    version='1.0.1',
+    version='1.0.3',
     description='A python module for configuring hierarchical class structures in yaml with defaults',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Added functionality for virtual parameters and alias parameters.

**Bug fixes:**

- Fixed issue with retrieving parameter values directly as attributes of Param class
- Handled 'self' in args to configurize_helper
- Handled inherited constructors when using configurize_helper
- Corrected propogation of init_base_on_construction argument when using configurize_helper
- Fixed issue with long comments for attributes defined by the Param class

**Features:**

 - Param's may now be virtual and overridden in child classes
 - Introduced AliasParams which are not configurable, but deterministically derived from other parameters